### PR TITLE
Sync eng/common directory with azure-sdk-tools repository for Tools P…p

### DIFF
--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -193,15 +193,14 @@ function Set-ChangeLogContent {
 
   try
   {
-    $VersionsSorted = [AzureEngSemanticVersion]::SortVersionStrings($ChangeLogEntries.Keys)
+    $ChangeLogEntries = $ChangeLogEntries.Values | Sort-Object -Descending -Property ReleaseStatus, ReleaseVersion
   }
   catch {
     LogError "Problem sorting version in ChangeLogEntries"
     return
   }
 
-  foreach ($version in $VersionsSorted) {
-    $changeLogEntry = $ChangeLogEntries[$version]
+  foreach ($changeLogEntry in $ChangeLogEntries) {
     $changeLogContent += $changeLogEntry.ReleaseTitle
     if ($changeLogEntry.ReleaseContent.Count -eq 0) {
       $changeLogContent += @("","")

--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -13,7 +13,7 @@ Components: Major.Minor.Patch-PrereleaseLabel.PrereleaseNumber.BuildNumber
 Note: A builtin Powershell version of SemVer exists in 'System.Management.Automation'. At this time, it does not parsing of PrereleaseNumber. It's name is also type accelerated to 'SemVer'.
 #>
 
-class AzureEngSemanticVersion {
+class AzureEngSemanticVersion : IComparable {
   [int] $Major
   [int] $Minor
   [int] $Patch
@@ -178,6 +178,31 @@ class AzureEngSemanticVersion {
     $this.DefaultAlphaReleaseLabel = "alpha"
   }
 
+  [int] CompareTo($other)
+  {
+    if ($other -isnot [AzureEngSemanticVersion]) {
+      throw "Cannot compare $other with $this"
+    }
+
+    $ret = $this.Major.CompareTo($other.Major)
+    if ($ret) { return $ret }
+
+    $ret = $this.Minor.CompareTo($other.Minor)
+    if ($ret) { return $ret }
+
+    $ret = $this.Patch.CompareTo($other.Patch)
+    if ($ret) { return $ret }
+
+    # Mimic PowerShell that uses case-insensitive comparisons by default.
+    $ret = [string]::Compare($this.PrereleaseLabel, $other.PrereleaseLabel, $true)
+    if ($ret) { return $ret }
+
+    $ret = $this.PrereleaseNumber.CompareTo($other.PrereleaseNumber)
+    if ($ret) { return $ret }
+
+    return ([int] $this.BuildNumber).CompareTo([int] $other.BuildNumber)
+  }
+
   static [string[]] SortVersionStrings([string[]] $versionStrings)
   {
     $versions = $versionStrings | ForEach-Object { [AzureEngSemanticVersion]::ParseVersionString($_) }
@@ -187,10 +212,7 @@ class AzureEngSemanticVersion {
 
   static [AzureEngSemanticVersion[]] SortVersions([AzureEngSemanticVersion[]] $versions)
   {
-    return ($versions | `
-            Sort-Object -Descending -Property `
-              Major, Minor, Patch, PrereleaseLabel, PrereleaseNumber, `
-              @{ Expression = { [int]$_.BuildNumber }; Descending = $true })
+    return $versions | Sort-Object -Descending
   }
 
   static [void] QuickTests()


### PR DESCRIPTION
…R 1479

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pnipeline failures and working on fixes.
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [x] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [x] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running generate.ps1. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version,

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
